### PR TITLE
schedule production snapshots with cron

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,6 +22,11 @@
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 12 15 2 *'  # February 15 at noon UTC
+    - cron: '0 12 15 5 *'  # May 15 at noon UTC
+    - cron: '0 12 15 8 *'  # August 15 at noon UTC
+    - cron: '0 12 15 11 *' # November 15 at noon UTC
 
 name: Create Production Snapshot
 


### PR DESCRIPTION
@shikokuchuo, I think it will be nice to schedule production snapshots with cron.  In the unlikely event that something is wrong with staging leading up to a snapshot, we could always disable the action in advance, revert to an earlier commit if a snapshot already happened, or regenerate one with the workflow dispatch option. 