### PR TITLE
Start migration to Netlify

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -28,10 +28,10 @@ on:
     - cron: '0 12 15 8 *'  # August 15 at noon UTC
     - cron: '0 12 15 11 *' # November 15 at noon UTC
 
-name: Create Production Snapshot
+name: Create Production Snapshot (legacy GitHub Pages version)
 
 jobs:
-  snapshot:
+  github-pages:
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,0 +1,70 @@
+# MIT License
+# 
+# Copyright (c) 2025 Jeroen Ooms, and Eli Lilly and Comany
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 15 2 *'  # February 15 at noon UTC
+    - cron: '0 12 15 5 *'  # May 15 at noon UTC
+    - cron: '0 12 15 8 *'  # August 15 at noon UTC
+    - cron: '0 12 15 11 *' # November 15 at noon UTC
+
+name: Create Production Snapshot
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install rversions.
+        shell: Rscript {0}
+        run: install.packages("rversions")
+
+      - name: Record production snapshot date.
+        run: date +%F > date.txt
+
+      - name: Record staging freeze date.
+        run: date -d "1 month ago" +"%Y-%m-15" > staging.txt
+
+      - name: Record snapshot R version.
+        shell: Rscript {0}
+        run: writeLines(rversions::r_release()$version, "r_version.txt")
+
+      - name: Save snapshot URL.
+        run: curl "https://raw.githubusercontent.com/r-multiverse/staging/main/snapshot.url" -Lo snapshot.url
+
+      - name: Clean files.
+        run: rm -rf .github README.md bin src
+
+      - name: Push to the snapshot branch.
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: snapshot
+          folder: .

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -45,8 +45,11 @@ jobs:
         shell: Rscript {0}
         run: install.packages("rversions")
 
-      - name: Record snapshot date.
+      - name: Record production snapshot date.
         run: date +%F > date.txt
+
+      - name: Record staging freeze date.
+        run: date -d "1 month ago" +"%Y-%m-15" > staging.txt
 
       - name: Record snapshot R version.
         shell: Rscript {0}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Production repository
+
+This is the R-multiverse Production repository.
+
+For all matters, please refer to <https://r-multiverse.org>.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,8 @@
 
 This is the R-multiverse Production repository.
 
+Production snapshots happen automatically.
+`snapshot.yaml` runs on a [quarterly schedule](https://r-multiverse.org/production.html#schedule) and commits configuration files to the [`snapshot`](https://github.com/r-multiverse/production/tree/snapshot) branch.
+On each commit to the [`snapshot`](https://github.com/r-multiverse/production/tree/snapshot) branch, [Netlify](https://www.netlify.com) downloads and publishes a snapshot of the [Staging](https://staging.r-multiverse.org) universe.
+
 For all matters, please refer to <https://r-multiverse.org>.

--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 <!doctype html>
 <html>
   <head>
-    <title>R-Multiverse Production</title>
+    <title>R-multiverse Production</title>
   </head>
   <body>
-    This is the R-Multiverse Production repository. Provide 'production.r-multiverse.org' to the 'repos' argument of install.packages().
+    <p>This is the R-multiverse Production repository. Provide 'https://production.r-multiverse.org' to the 'repos' argument of install.packages().</p>
+    <p>The R-multiverse Production repository is powered by <a href="https://www.netlify.com">Netlify</a>.</p>
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  command = "cat snapshot.url | xargs curl -Lo snapshot.zip && unzip snapshot.zip && rm -f snapshot.zip"


### PR DESCRIPTION
This PR begins the migration to Netlify.

`snapshot.yaml` runs on a quarterly schedule and pushes to a branch called "snapshot". Then, Netlify runs the command in `netlify.toml` to download and publish the snapshot. The separate branch allows us to commit to `main` without accidentally triggering a Production snapshot.

This PR keeps the existing GitHub Pages deployment in `github-pages.yaml`. We can remove it (and `bin` and `src`) when we fully migrate to the Netlify site.

FYI @shikokuchuo, @jeroen, @maelle. After merging, I will set up the Netlify site and connect it to the `snapshot` branch. 